### PR TITLE
make Rich dependency optional + add easybuild.tools.output module

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -213,7 +213,7 @@ class EasyBlock(object):
         self.current_step = None
 
         # Create empty progress bar
-        self.progressbar = None
+        self.progress_bar = None
         self.pbar_task = None
 
         # list of loaded modules
@@ -304,20 +304,20 @@ class EasyBlock(object):
         self.log.info("Closing log for application name %s version %s" % (self.name, self.version))
         fancylogger.logToFile(self.logfile, enable=False)
 
-    def set_progressbar(self, progressbar, task_id):
+    def set_progress_bar(self, progress_bar, task_id):
         """
         Set progress bar, the progress bar is needed when writing messages so
         that the progress counter is always at the bottom
         """
-        self.progressbar = progressbar
+        self.progress_bar = progress_bar
         self.pbar_task = task_id
 
     def advance_progress(self, tick=1.0):
         """
         Advance the progress bar forward with `tick`
         """
-        if self.progressbar and self.pbar_task is not None:
-            self.progressbar.advance(self.pbar_task, tick)
+        if self.progress_bar and self.pbar_task is not None:
+            self.progress_bar.advance(self.pbar_task, tick)
 
     #
     # DRY RUN UTILITIES
@@ -3653,7 +3653,7 @@ def print_dry_run_note(loc, silent=True):
     dry_run_msg(msg, silent=silent)
 
 
-def build_and_install_one(ecdict, init_env, progressbar=None, task_id=None):
+def build_and_install_one(ecdict, init_env, progress_bar=None, task_id=None):
     """
     Build the software
     :param ecdict: dictionary contaning parsed easyconfig + metadata
@@ -3701,10 +3701,11 @@ def build_and_install_one(ecdict, init_env, progressbar=None, task_id=None):
         print_error("Failed to get application instance for %s (easyblock: %s): %s" % (name, easyblock, err.msg),
                     silent=silent)
 
-    # Setup progressbar
-    if progressbar and task_id is not None:
-        app.set_progressbar(progressbar, task_id)
-        _log.info("Updated progressbar instance for easyblock %s" % easyblock)
+    # Setup progress bar
+    if progress_bar and task_id is not None:
+        app.set_progress_bar(progress_bar, task_id)
+        _log.info("Updated progress bar instance for easyblock %s", easyblock)
+
     # application settings
     stop = build_option('stop')
     if stop is not None:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -73,7 +73,13 @@ from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.testing import create_test_report, overall_test_report, regtest, session_state
-from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
+
+try:
+    from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
+    HAVE_RICH = True
+except ImportError:
+    HAVE_RICH = False
+
 
 _log = None
 
@@ -99,13 +105,14 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
     return [(ec_file, generated)]
 
 
-def build_and_install_software(ecs, init_session_state, exit_on_failure=True, progress=None):
+def build_and_install_software(ecs, init_session_state, exit_on_failure=True, progress_bar=None):
     """
     Build and install software for all provided parsed easyconfig files.
 
     :param ecs: easyconfig files to install software with
     :param init_session_state: initial session state, to use in test reports
     :param exit_on_failure: whether or not to exit on installation failure
+    :param progress_bar: ProgressBar instance to use to report progress
     """
     # obtain a copy of the starting environment so each build can start afresh
     # we shouldn't use the environment from init_session_state, since relevant env vars might have been set since
@@ -113,15 +120,20 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True, pr
     init_env = copy.deepcopy(os.environ)
 
     # Initialize progress bar with overall installation task
-    if progress:
-        task_id = progress.add_task("", total=len(ecs))
+    if progress_bar:
+        task_id = progress_bar.add_task("", total=len(ecs))
+    else:
+        task_id = None
+
     res = []
     for ec in ecs:
-        if progress:
-            progress.update(task_id, description=ec['short_mod_name'])
+
+        if progress_bar:
+            progress_bar.update(task_id, description=ec['short_mod_name'])
+
         ec_res = {}
         try:
-            (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env, progressbar=progress,
+            (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env, progress_bar=progress_bar,
                                                                       task_id=task_id)
             ec_res['log_file'] = app_log
             if not ec_res['success']:
@@ -527,18 +539,22 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # build software, will exit when errors occurs (except when testing)
     if not testing or (testing and do_build):
         exit_on_failure = not (options.dump_test_report or options.upload_test_report)
-        # Create progressbar around software to install
-        progress_bar = Progress(
-            TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total})"),
-            BarColumn(),
-            "[progress.percentage]{task.percentage:>3.1f}%",
-            "•",
-            TimeElapsedColumn()
-        )
-        with progress_bar:
-            ecs_with_res = build_and_install_software(
-                ordered_ecs, init_session_state, exit_on_failure=exit_on_failure,
-                progress=progress_bar)
+
+        if HAVE_RICH:
+            # Create progressbar around software to install
+            progress_bar = Progress(
+                TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total})"),
+                BarColumn(),
+                "[progress.percentage]{task.percentage:>3.1f}%",
+                "•",
+                TimeElapsedColumn()
+            )
+            with progress_bar:
+                ecs_with_res = build_and_install_software(ordered_ecs, init_session_state,
+                                                          exit_on_failure=exit_on_failure,
+                                                          progress_bar=progress_bar)
+        else:
+            ecs_with_res = build_and_install_software(ordered_ecs, init_session_state, exit_on_failure=exit_on_failure)
     else:
         ecs_with_res = [(ec, {}) for ec in ordered_ecs]
 

--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# #
+# Copyright 2021-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Tools for controlling output to terminal produced by EasyBuild.
+
+:author: Kenneth Hoste (Ghent University)
+:author: Jørgen Nordmoen (University of Oslo)
+"""
+try:
+    from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
+    HAVE_RICH = True
+except ImportError:
+    HAVE_RICH = False
+
+
+class DummyProgress(object):
+    """Shim for Rich's Progress class."""
+
+    # __enter__ and __exit__ must be implemented to allow use as context manager
+    def __enter__(self, *args, **kwargs):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    # dummy implementations for methods supported by rich.progress.Progress class
+    def add_task(self, *args, **kwargs):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+
+def create_progress_bar():
+    """
+    Create progress bar to display overall progress.
+
+    Returns rich.progress.Progress instance if the Rich Python package is available,
+    or a shim DummyProgress instance otherwise.
+    """
+    if HAVE_RICH:
+        progress_bar = Progress(
+            TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total})"),
+            BarColumn(),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            TimeElapsedColumn()
+        )
+    else:
+        progress_bar = DummyProgress()
+
+    return progress_bar

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,4 +63,5 @@ archspec; python_version >= '2.7'
 cryptography==3.3.2; python_version == '2.7'
 cryptography; python_version >= '3.5'
 
-rich; python_version >= '2.7'
+# rich is only supported for Python 3.6+
+rich; python_version >= '3.6'


### PR DESCRIPTION
@nordmoen Some cleanup/re-organization for https://github.com/easybuilders/easybuild-framework/pull/3823.

The biggest changes are making Rich optional, and introducing a new `easybuild.tools.output` module (where we can keep other functionality that leverages Rich to control the output produced by EasyBuild).

I've also consistently used `progress_bar` .