### PR TITLE
use transient progress bar, so it disappears when installation is complete

### DIFF
--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -67,7 +67,8 @@ def create_progress_bar():
             BarColumn(),
             "[progress.percentage]{task.percentage:>3.1f}%",
             "•",
-            TimeElapsedColumn()
+            TimeElapsedColumn(),
+            transient=True,
         )
     else:
         progress_bar = DummyProgress()


### PR DESCRIPTION
@nordmoen For https://github.com/easybuilders/easybuild-framework/pull/3823.

This fixes the broken tests, but it makes sense regardless imho...

see https://rich.readthedocs.io/en/latest/progress.html#transient-progress